### PR TITLE
refactor the recent activity and deck onClick function to send the db…

### DIFF
--- a/client/src/actions/actions_navBar.js
+++ b/client/src/actions/actions_navBar.js
@@ -1,7 +1,6 @@
 import { PAGE_SELECTED } from './actionTypes';
 
 export const selectPage = (pageName) => {
-  console.log('clicked');
   return {
     type: PAGE_SELECTED,
     pageName: pageName

--- a/client/src/actions/actions_practicePage.js
+++ b/client/src/actions/actions_practicePage.js
@@ -27,10 +27,10 @@ export const selectNextCard = () => {
   };
 };
 
-export const selectRecentActivityDeck = (topic) => {
+export const selectRecentActivityDeck = (dbID) => {
   return {
     type: SELECT_RECENT_ACTIVITY_DECK,
-    topic
+    dbID
   };
 };
 

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -31,7 +31,7 @@ class App extends Component {
     fetch('/api/profileInfo', { credentials: 'include' })
       .then(res => res.json())
       .then( data => {
-        console.log('data has been fetched', data);
+        console.log('all decks data has been fetched', data);
         const name = data.display;
         const badgeUrls = data.decks.filter( deck => deck.has_badge ).map( deck => deck.badge);
         const photo = data.photo || 'https://www.cbdeolali.org.in/drupal/sites/default/files/Section%20Head/Alternative-Profile-pic_5.jpg';
@@ -51,6 +51,7 @@ class App extends Component {
       })
       .then(res => res.json())
       .then(recentDecks => {
+        console.log('recent deck information has been fetched', recentDecks);
         practicePageState.recentUserDecksInfo = recentDecks;
         this.props.loadPracticePage(practicePageState);
       })

--- a/client/src/components/Deck.js
+++ b/client/src/components/Deck.js
@@ -13,10 +13,10 @@ class Deck extends Component {
   }
   handleDeckClick() {
     this.props.selectPage('Practice Page');
-    this.props.onDeckSelect(this.props.id);
+    this.props.onDeckSelect(this.props.index);
     const endpoint = '/api/recentDecks';
     const postBody = {
-      topic: this.props.topic,
+      deckDbID: this.props.dbID,
       timestamp: Date.now()
     };
 

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -39,6 +39,7 @@ class Profile extends Component {
                   key={idx} 
                   recentDeck={recentDeck} 
                   topic={recentDeck.topic}
+                  dbID={recentDeck.dbID}
                 />
               );
             })}

--- a/client/src/components/RecentActivity.js
+++ b/client/src/components/RecentActivity.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import {Link} from 'react-router-dom'
+import {Link} from 'react-router-dom';
 import { Grid, Image } from 'semantic-ui-react';
 
 import { bindActionCreators } from 'redux';
@@ -15,12 +15,12 @@ class RecentActivity extends Component {
 
   handleRecentDeckClick() {
     this.props.selectPage('Practice Page');
-    this.props.selectRecentActivityDeck(this.props.topic);
-
+    this.props.selectRecentActivityDeck(this.props.dbID);
+    console.log('deck has been selected with dbID', this.props.dbID);
     // also send a post request to the api endpoint to update recent deck activity
     const endpoint = '/api/recentDecks';
     const postBody = {
-      topic: this.props.topic,
+      deckDbID: this.props.dbID,
       timestamp: Date.now()
     };
 

--- a/client/src/containers/DecksContainer.js
+++ b/client/src/containers/DecksContainer.js
@@ -52,7 +52,8 @@ class DecksContainer extends Component {
                   <Deck
                     topic={deck.topic}
                     image={deck.image}
-                    id={index}
+                    dbID={deck.id}
+                    index={index}
                     key={index}
                     onDeckSelect={this.props.onDeckSelect}
                   />)

--- a/client/src/containers/VisiblePracticePage.js
+++ b/client/src/containers/VisiblePracticePage.js
@@ -6,7 +6,6 @@ import PracticePage from '../components/PracticePage';
 import AudioGraph from '../components/AudioGraph';
 
 const mapStateToProps = (state) => {
-  console.log('state tree', state);
   return {
     currentCard: state.practicePage.currentCard,
     currentDeck: state.practicePage.currentDeck,

--- a/client/src/reducers/reducer_practicePage.js
+++ b/client/src/reducers/reducer_practicePage.js
@@ -117,6 +117,7 @@ const practicePage = (state = initialState, action) => {
     case 'LOAD_PRACTICE_PAGE':
       return action.practicePageState;
     case 'SELECT_DECK':
+      console.log('deck has been selected with index', action.deckIndex);
       return {
         currentDeck: state.allDecks[action.deckIndex],
         currentCard: state.allDecks[action.deckIndex].cards[0],
@@ -125,11 +126,11 @@ const practicePage = (state = initialState, action) => {
         recentUserDecksInfo: state.recentUserDecksInfo
       };
     case 'SELECT_RECENT_ACTIVITY_DECK':
-      console.log('a recent activity deck has been selected with topic', action.topic);
-      const selectedTopic = action.topic;
+      //console.log('a recent activity deck has been selected with topic', action.topic);
+      const selectedDeckID = action.dbID;
       let newDeck;
       state.allDecks.forEach(deck => {
-        if (deck.topic === selectedTopic) {
+        if (deck.id === selectedDeckID) {
           newDeck = deck;
         }
       });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -273,22 +273,15 @@ router.route('/recentDecks')
   })
   .post((req, res) => {
     const userID = req.user.id;
-    const { topic, timestamp } = req.body;
-    let deckID;
-    // find the id of the deck associated with that topic
-    knex.select('id').from('decks').where({topic})
-      .then(deckRow => {
-        deckID = deckRow[0].id;
-        // check to see if that deck is already there -- if so we'll just update the timestamp
-        return knex.select().from('users_recent_decks').where({deck_id: deckID});
-      })
+    const { deckDbID, timestamp } = req.body;
+    knex.select().from('users_recent_decks').where({deck_id: deckDbID})
       .then(existingDeckInfo => {
         console.log('existingDeckInfo', existingDeckInfo);
-        console.log('deckID inside existingDeckInfo block', deckID);
+        console.log('deckDbID inside existingDeckInfo block', deckDbID);
         // if that deck isn't already there, then make an insertion
         if (!existingDeckInfo.length) {
           console.log('deck not found -- inserting into users_recent_decks');
-          knex('users_recent_decks').insert({user_id: userID, deck_id: deckID, time_stamp: timestamp})
+          knex('users_recent_decks').insert({user_id: userID, deck_id: deckDbID, time_stamp: timestamp})
             .then(insertionInfo => {
               // now we need to take a look at how many rows are there -- if > 3, we need to delete the oldest
               return knex.select().from('users_recent_decks').where({user_id: userID});
@@ -321,7 +314,7 @@ router.route('/recentDecks')
             });
         } else {
           // the deck was already there -- just update the timestamp
-          knex('users_recent_decks').where({deck_id: deckID}).update({time_stamp: timestamp})
+          knex('users_recent_decks').where({deck_id: deckDbID}).update({time_stamp: timestamp})
             .then(successfulUpdateResult => {
               console.log('successful update');
               res.sendStatus(201);


### PR DESCRIPTION
…ID of the selected deck so as to avoid the ambiguity that could arise from looking up deck ID's via topics (can be multiple user created decks that have the same topic).
future change idea in the same vein -- now that all the decks have the dbIDs mapped to them, completely remove the all decks concept and fetch cards on deck click instead. 